### PR TITLE
Fix bugs

### DIFF
--- a/docker-compose-a.yml
+++ b/docker-compose-a.yml
@@ -38,7 +38,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       

--- a/docker-compose-b.yml
+++ b/docker-compose-b.yml
@@ -42,7 +42,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       

--- a/docker-compose-c.yml
+++ b/docker-compose-c.yml
@@ -51,7 +51,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       

--- a/run.py
+++ b/run.py
@@ -150,6 +150,7 @@ def prompt_for_missing_params(args):
             try:
                 ipaddress.ip_address(target_ip)
                 args.target_ip = target_ip
+                break
             except ValueError:
                 print_error("Target IP must be a valid IPv4 or IPv6 address.")
 


### PR DESCRIPTION
- In `run.py` when user entered a valid IP didn't exit from the loop
- In Docker compose files, because of https://github.com/docker-library/postgres/pull/1259 Postgres volumes path were unaccepted.